### PR TITLE
Fix sponsor page h-controller.height problem

### DIFF
--- a/app/js/init-page.js
+++ b/app/js/init-page.js
@@ -3,8 +3,16 @@ require('dom.js');
 var initPage = location.hash.slice(8) || 'home';
 location.hash = '#target-' + initPage;
 initPage = 'page-' + initPage;
-Qid('h-controller').style.height
-	= Qid(initPage).offsetHeight + 'px';
+var resize_things = function() {
+	Qid('h-controller').style.height =
+		Qid(initPage).offsetHeight + 'px';
+};
+
+resize_things();
+
+Qall('#page-sponsor img', function(element) {
+	addEvent(element, 'load', resize_things);
+});
 
 setTimeout(function() {
 	addClass(Qid('image-group-title'), 'active');

--- a/app/js/navbar.js
+++ b/app/js/navbar.js
@@ -29,17 +29,17 @@ for(var i=0; i<pages.length; ++i)
 				}
 			return function() {
 				footerSponsorToggle();
-				Qid('h-controller').style.height
-				= Qid('page-'+which).offsetHeight + 'px';
+				Qid('h-controller').style.height =
+					Qid('page-'+which).offsetHeight + 'px';
 				removeClass(Qid('link-'+activePage), 'active');
 				activePage = which;
 				addClass(Qid('link-'+activePage), 'active');
 			};
 		}()
-	);	
+	);
 
 // source in /js/lib/resize-handler
 resizeHandler.regist(function() {
-	Qid('h-controller').style.height
-	= Qid('page-'+activePage).offsetHeight + 'px';
+	Qid('h-controller').style.height =
+		Qid('page-'+activePage).offsetHeight + 'px';
 });


### PR DESCRIPTION
首先，會發生問題的路徑是：直接從網址列打開 [http://sitcon.org/2016/#target-sponsor](http://sitcon.org/2016/#target-sponsor)，如果先點開首頁再透過上面的 menu 切換 tab 則不會出現此 bug

bug 出現的原因是因為，`init-page.js` 內計算 `#h-controller` 的 `height` 時，sponsor logo 尚未全部載入完成，所以計算的高度會少了圖片的高度

解法是在 sponsor logo 載入之後重新計算 `#h-controller` 的高度
